### PR TITLE
Switch to Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # codex_test_250520
 
-test content
+This project uses [Poetry](https://python-poetry.org/) for dependency management with Python **3.12**.
 
-python
+## Setup
 
-nv
+1. Install Python 3.12 (e.g. with [pyenv](https://github.com/pyenv/pyenv)).
+2. Install Poetry.
+3. Run `poetry install` to create the virtual environment.
+
+## Dependencies
+
+The project includes `numpy` and `opencv-python` as required packages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "codex_test_250520"
+version = "0.1.0"
+description = ""
+authors = ["Codex <codex@openai.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.12,<3.13"
+numpy = "*"
+opencv-python = "*"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- update README to reference Python 3.12
- list numpy and opencv-python as dependencies
- configure Poetry to require Python 3.12

## Testing
- `poetry --version`
- `python --version`
- `python3.12 --version`
- `poetry check`
- `poetry lock` *(fails: cannot reach PyPI)*