### PR TITLE
Refactor package layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ This project uses [Poetry](https://python-poetry.org/) for dependency management
 1. Install Python 3.12 (e.g. with [pyenv](https://github.com/pyenv/pyenv)).
 2. Install Poetry.
 3. Run `poetry install` to create the virtual environment.
+4. The source code resides in the `imgutil/` package.
+   Run the grayscale utility with `python -m imgutil.grayscale <input.png>`.
 
 ## Dependencies
 
-The project includes `numpy` and `opencv-python` as required packages.
+The project requires `numpy` **2.2.6** and `opencv-python` **4.11.0.86**.
 
 ## Notes
 
-`grayscale.py` now reads and writes images using `np.fromfile` and
+`imgutil/grayscale.py` now reads and writes images using `np.fromfile` and
 `cv2.imdecode/encode`. This allows the script to handle file paths that
 contain non-ASCII characters (e.g. Japanese) on Windows.

--- a/imgutil/grayscale.py
+++ b/imgutil/grayscale.py
@@ -7,7 +7,7 @@ import numpy as np
 
 def main():
     if len(sys.argv) != 2:
-        print("Usage: python grayscale.py <input.png>")
+        print("Usage: python -m imgutil.grayscale <input.png>")
         sys.exit(1)
 
     input_path = Path(sys.argv[1])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,12 @@ name = "codex_test_250520"
 version = "0.1.0"
 description = ""
 authors = ["Codex <codex@openai.com>"]
+packages = [{include = "imgutil"}]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.13"
-numpy = "*"
-opencv-python = "*"
+numpy = "2.2.6"
+opencv-python = "4.11.0.86"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
## Summary
- move the grayscale utility under `imgutil/`
- note new package location in README
- configure Poetry to include the `imgutil` package
- adjust usage message in the script
- pin versions for numpy and opencv-python

## Testing
- `python -m imgutil.grayscale` *(fails: ModuleNotFoundError: No module named 'cv2')*
