### PR TITLE
Restore imgutil package at project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This project uses [Poetry](https://python-poetry.org/) for dependency management
 1. Install Python 3.12 (e.g. with [pyenv](https://github.com/pyenv/pyenv)).
 2. Install Poetry.
 3. Run `poetry install` to create the virtual environment.
-4. The source code resides in the `imgutil/` package.
-   Run the grayscale utility with `python -m imgutil.grayscale <input.png>`.
+4. The source code resides in the `imgutil/` package at the project root.
+   Run the grayscale utility with
+   `poetry run python -m imgutil.grayscale <input.png>`.
 
 ## Dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ numpy = "2.2.6"
 opencv-python = "4.11.0.86"
 
 [tool.poetry.dev-dependencies]
+pytest = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
## Summary
- remove unnecessary ROOT directory
- move `imgutil` back to project root
- add pytest as dev dependency in Poetry
- update README with new run instructions

## Testing
- `poetry run python -m imgutil.grayscale test.png` *(fails: File not found)*
- `poetry run pytest -q` *(fails: Command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.